### PR TITLE
fix(readme): correct install script reference (install.sh → init.sh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Each agent lives in `.claude/agents/` as a markdown file containing focused inst
 ## Quick Start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/charles-adedotun/claude-code-sub-agents/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/charles-adedotun/claude-code-sub-agents/main/init.sh | bash
 ```
 
 Then in your project:


### PR DESCRIPTION
## Summary
The Quick Start curl command referenced `install.sh` which doesn't exist (404).
The actual installer script is `init.sh`.

## Fix
- Changed `install.sh` → `init.sh` in the curl command

🤖 Generated with [Claude Code](https://claude.com/claude-code)