### PR TITLE
[codex] Add Dependabot hygiene config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "America/Chicago"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Add a minimal Dependabot configuration for the repo's existing GitHub Actions workflow dependency surface.

- Group GitHub Actions updates together
- Run on a monthly Central time schedule to avoid unnecessary PR noise for this lightweight repo

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`
- `git diff --check`
